### PR TITLE
Learning lab updates: chatbot, navigational features

### DIFF
--- a/docs/_includes/watson_assistant.html
+++ b/docs/_includes/watson_assistant.html
@@ -94,11 +94,12 @@ window.watsonAssistantChatOptions = {
                 }
             }
         }
-		instance.showLauncherGreetingMessage(1000);
+		// instance.showLauncherGreetingMessage(1000);
 		instance.on({ type: 'customResponse', handler: customResponseHandler });
 		instance.on({ type: 'pre:receive', handler: preReceiveHandler });
 		instance.render(); 
-		setTimeout(function() { nsToast()}, 100);
+        // commenting out toast for learning lab.
+		// setTimeout(function() { nsToast()}, 100);
 	}
   };
   setTimeout(function(){

--- a/docs/_layouts/chapter.html
+++ b/docs/_layouts/chapter.html
@@ -65,6 +65,13 @@
               {% assign pagename = "/" %}
           {% endif %}
           {% assign pages = site.pages | where: "parent", pagename | sort: "order" %}
+          {% assign first_page = pages | first %}
+          {% if page.start_button == nil or page.start_button == true %}
+          <ul>
+            <li><a href="{{ site.url }}{{ site.baseurl }}{{ first_page.url }}">▶️ START THE LAB</a></li>
+          </ul>
+          {% endif %}
+          <hr />
           <ul>
           {% for apage in pages %}
               <li><a href="{{ site.url }}{{ site.baseurl }}{{ apage.url }}">{{ apage.title }}</a></li>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -58,6 +58,40 @@
       <div class="content" style="padding-left:30px;padding-right:30px;">
       {{ content }}
       </div>
+      <div class="hr_menu" style="text-align:right">
+        <hr />
+        {% for p in site.pages %}
+          {% assign p_name = p.url | split: '/' | last %}
+          {% if p_name == page.parent %}
+            {% assign parent_page = p %}
+            {% break %}
+          {% endif %}
+        {% endfor %}
+        {% assign sibling_pages = site.pages | where: "parent", page.parent | sort: "order" %}
+        {% for sibling_page in sibling_pages %}
+          {% if sibling_page.url == page.url %}
+            {% unless forloop.first %}
+              {% assign prev_index = forloop.index0 | minus:1 %}
+              {% assign prev_page = sibling_pages[prev_index] %}
+            {% endunless %}
+            {% unless forloop.last %}
+              {% assign next_index = forloop.index0 | plus:1 %}
+              {% assign next_page = sibling_pages[next_index] %}
+            {% endunless %}
+            {% break %}
+          {% endif %}
+        {% endfor %}
+        <ul>
+          {% if prev_page %}
+          <li><a href="{{ site.url }}{{ site.baseurl }}{{ prev_page.url }}">&lt;&lt; PREV: {{ prev_page.title }}</a></li>
+          {% endif %}
+          {% if next_page %}
+          <li><a href="{{ site.url }}{{ site.baseurl }}{{ next_page.url }}">NEXT: {{ next_page.title }} &gt;&gt;</a></li>
+          {% elsif parent_page %}
+          <li><a href="{{ site.url }}{{ site.baseurl }}{{ parent_page.url }}">🛑 FINISHED</a></li>
+          {% endif %}
+        </ul>
+      </div>
     </main>
     <!-- Bootstrap JS and jQuery -->
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>

--- a/docs/module1/module1.md
+++ b/docs/module1/module1.md
@@ -3,6 +3,7 @@ title: Module 1 - Configuration & Integration
 permalink: /module1/
 parent: /
 layout: chapter
+start_button: false
 order: 1
 ---
 


### PR DESCRIPTION
This PR was created to address the following problems:
# Problems
- Chatbot has a `toaster` feature which pulls out welcoming message at the start. However, this is annoying and unnecessary for the learning lab as it clutters up screen and buttons behind.
- Navigational Features
  - The current lab does NOT have 'start' button to initiate the lab. It is understandable that the first module should be the starting point. However, it would be more clear to simply click the 'start' button to initiate the module.
  - The current lab does NOT have `previous` and `next` button at the end of each sub modules, and therefore, if users want to navigate to the next module, they have to scroll all the way up and click the appropriate sub module link by themselves, which is confusing.
  - The current lab does NOT have `finished` button, that would conveniently navigate user to the parent module when all the  sub modules are covered.

# Solutions
- Chatbot's toaster feature is now disabled
- Navigational features now includes start, finish, prev, next button with easy understanding of where to go next.