### PR TITLE
Fix for broken CSS over HTTPS

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,3 +5,4 @@ defaults:
     values:
       layout: "default"
 
+url: https://labs.neuralseek.com


### PR DESCRIPTION
I believe setting site.url in the _config.yml file will fix the issue of trying to reach CSS stylesheets over HTTP